### PR TITLE
Added necessary XInitThreads() call

### DIFF
--- a/src-native/linux/nativeInit.c
+++ b/src-native/linux/nativeInit.c
@@ -29,6 +29,7 @@ void gtk_init_with_empty_args()
 	int argc = 0;
 	char ** argv = malloc(sizeof(char*));
 	argv[0] = "";
+	XInitThreads();
     if (gtk_init_check (&argc, &argv) == FALSE) {
 		fprintf(stderr, "Failed to start GTK\n");
 	}


### PR DESCRIPTION
Hello,
I am using Xubuntu OS and I am met the following error while using your library:
"[xcb] Unknown sequence number while processing queue
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
mktrayicon: xcb_io.c:274: poll_for_event: Assertion `!xcb_xlib_threads_sequence_lost' failed."
I am searching the decision and find the following suggestion:
http://stackoverflow.com/questions/18647475/threading-problems-with-gtk
I suppose, that decision above should be added to the master branch.
Thank you for your attention.
